### PR TITLE
[fix JENKINS-66898] make the cache thread safe

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
@@ -8,6 +8,7 @@ import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import jenkins.util.SystemProperties;
 
@@ -48,9 +49,16 @@ import jenkins.util.SystemProperties;
     private boolean removeIfExpiredCacheDirectory(FilePath library) throws IOException, InterruptedException {
         final FilePath lastReadFile = new FilePath(library, LibraryCachingConfiguration.LAST_READ_FILE);
         if (lastReadFile.exists()) {
-            if (System.currentTimeMillis() - lastReadFile.lastModified() > TimeUnit.DAYS.toMillis(EXPIRE_AFTER_READ_DAYS)) {
-                library.deleteRecursive();
-                library.withSuffix("-name.txt").delete();
+            ReentrantReadWriteLock retrieveLock = LibraryAdder.getReadWriteLockFor(library.getName());
+            retrieveLock.writeLock().lockInterruptibly();
+            try {
+                if (System.currentTimeMillis() - lastReadFile.lastModified() > TimeUnit.DAYS.toMillis(EXPIRE_AFTER_READ_DAYS)) {
+                
+                    library.deleteRecursive();
+                    library.withSuffix("-name.txt").delete();
+                }
+            } finally {
+                retrieveLock.writeLock().unlock();
             }
             return true;
         }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
@@ -32,6 +32,9 @@ THE SOFTWARE.
         <f:textbox />
     </f:entry>
     <j:if test="${h.hasPermission(app.ADMINISTER)}">
-        <f:validateButton title="${%Clear cache}" progress="${%Clearing...}" method="clearCache" with="name" />
+        <f:entry title="${%Force clear cache}" field="forceDelete">
+          <f:checkbox/>
+        </f:entry>
+        <f:validateButton title="${%Clear cache}" progress="${%Clearing...}" method="clearCache" with="name,forceDelete" />
     </j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-forceDelete.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-forceDelete.html
@@ -2,5 +2,5 @@
     To avoid that clearing the cache interferes with running builds this process is normally guarded by locks.
     Pressing the <i>Clear Cache</i> button will wait for a maximum of 10 seconds to get a lock.<br/>
     By checking this option, the library will be deleted immediately without acquiring a lock. This can lead to build errors 
-    if a build is copying the library from the cache while it gets delete. This risk is all the greater, the larger the library is.
+    if a build is copying the library from the cache while it gets deleted. This risk is all the greater, the larger the library is.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-forceDelete.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-forceDelete.html
@@ -1,0 +1,6 @@
+<div>
+    To avoid that clearing the cache interferes with running builds this process is normally guarded by locks.
+    Pressing the <i>Clear Cache</i> button will wait for a maximum of 10 seconds to get a lock.<br/>
+    By checking this option, the library will be deleted immediately without acquiring a lock. This can lead to build errors 
+    if a build is copying the library from the cache while it gets delete. This risk is all the greater, the larger the library is.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -480,6 +480,7 @@ public class LibraryAdderTest {
     public void parallelBuildsDontInterfereWithExpiredCache() throws Throwable {
         // Add a few files to the library so the deletion is not too fast
         // Before fixing JENKINS-66898 this test was failing almost always
+        // with a build failure
         sampleRepo.init();
         sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
         sampleRepo.write("vars/bar.groovy", "def call() { echo 'bar' }");
@@ -507,10 +508,12 @@ public class LibraryAdderTest {
         cache.touch(oldMillis);
         QueueTaskFuture<WorkflowRun> f1 = p1.scheduleBuild2(0);
         QueueTaskFuture<WorkflowRun> f2 = p2.scheduleBuild2(0);
-        WorkflowRun r1 = r.assertBuildStatus(Result.SUCCESS, f1);
-        WorkflowRun r2 = r.assertBuildStatus(Result.SUCCESS, f2);
-        r.assertLogContains("is due for a refresh after", r1);
-        r.assertLogContains("Library library@master is cached. Copying from home.", r2);
+        r.assertBuildStatus(Result.SUCCESS, f1);
+        r.assertBuildStatus(Result.SUCCESS, f2);
+        // Disabling these 2 checks as they are flaky
+        // Occasionally the second job runs first and then build output doesn't match
+        // r.assertLogContains("is due for a refresh after", f1.get());
+        // r.assertLogContains("Library library@master is cached. Copying from home.", f2.get());
     }
 
     @Issue("JENKINS-68544")

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -28,6 +28,7 @@ import com.cloudbees.hudson.plugins.folder.Folder;
 import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
@@ -36,6 +37,8 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.slaves.WorkspaceList;
 import hudson.scm.SubversionSCM;
 import hudson.scm.ChangeLogSet;
+
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -472,4 +475,41 @@ public class LibraryAdderTest {
         r.assertLogContains("called Foo", b);
     }
 
+    @Issue("JENKINS-66898")
+    @Test
+    public void parallelBuildsDontInterfereWithExpiredCache() throws Throwable {
+        // Add a few files to the library so the deletion is not too fast
+        // Before fixing JENKINS-66898 this test was failing almost always
+        sampleRepo.init();
+        sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
+        sampleRepo.write("vars/bar.groovy", "def call() { echo 'bar' }");
+        sampleRepo.write("vars/foo2.groovy", "def call() { echo 'foo2' }");
+        sampleRepo.write("vars/foo3.groovy", "def call() { echo 'foo3' }");
+        sampleRepo.write("vars/foo4.groovy", "def call() { echo 'foo4' }");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration config = new LibraryConfiguration("library",
+                new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        config.setDefaultVersion("master");
+        config.setImplicit(true);
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        GlobalLibraries.get().getLibraries().add(config);
+        WorkflowJob p1 = r.createProject(WorkflowJob.class);
+        WorkflowJob p2 = r.createProject(WorkflowJob.class);
+        p1.setDefinition(new CpsFlowDefinition("foo()", true));
+        p2.setDefinition(new CpsFlowDefinition("foo()", true));
+        WorkflowRun b1 = r.buildAndAssertSuccess(p1);
+        LibrariesAction action = b1.getAction(LibrariesAction.class);
+        LibraryRecord record = action.getLibraries().get(0);
+        FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child(record.getDirectoryName());
+        //Expire the cache
+        long oldMillis = ZonedDateTime.now().minusMinutes(35).toInstant().toEpochMilli();
+        cache.touch(oldMillis);
+        QueueTaskFuture<WorkflowRun> f1 = p1.scheduleBuild2(0);
+        QueueTaskFuture<WorkflowRun> f2 = p2.scheduleBuild2(0);
+        WorkflowRun r1 = r.assertBuildStatus(Result.SUCCESS, f1);
+        WorkflowRun r2 = r.assertBuildStatus(Result.SUCCESS, f2);
+        r.assertLogContains("is due for a refresh after", r1);
+        r.assertLogContains("Library library@master is cached. Copying from home.", r2);
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -177,7 +177,7 @@ public class LibraryCachingConfigurationTest {
         assertThat(new File(cache.getRemote()), anExistingDirectory());
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), anExistingFile());
         // Clear the cache. TODO: Would be more realistic to set up security and use WebClient.
-        ExtensionList.lookupSingleton(LibraryCachingConfiguration.DescriptorImpl.class).doClearCache("library");
+        ExtensionList.lookupSingleton(LibraryCachingConfiguration.DescriptorImpl.class).doClearCache("library", false);
         assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
     }


### PR DESCRIPTION
fix [JENKINS-66898](https://issues.jenkins.io/browse/JENKINS-66898)

This is the same as https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/151

there are several conditions where we have race conditions in
the shared library cache :

- when multiple builds start at the same time and try to use an expired
  cached shared library. The first one will start deleting the cache
  dir. The second one will see that the cachedir was modified and
  consider it up-to-date while the first is still deleting

-  when multiple builds start at the same time with no cache entry
  available. The first has created the cachedir but not yet the lock
  file, the second will not see the lockfile but the cachedir

- the background cleaner is about to clean when a new build starts

- an administrator decides to clear the cache right before a new build
  wants to use the cache library

All these can lead to the situtation that the library for a build is
copied only partially and fails the build

This PR fixes the race conditions by using a ReadWriteLock to ensure nobody reads when a cache entry is created/updated/deleted

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
