### PR TITLE
Backdate core dep from 2.303.x to 2.289.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,14 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.303.1</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
+                <artifactId>bom-2.289.x</artifactId>
                 <version>1008.vb9e22885c9cf</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
When splitting this plugin out of `workflow-cps-global-lib` I kept the baseline intact. This had been updated to 2.303.x a few months ago, for no reason that I can ascertain: as mentioned in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/119#issuecomment-1136531975, the plugin seems to build fine on 2.289.x and there is no apparent mention of this plugin in either https://github.com/jenkinsci/jenkins/pull/5320 or the associated Jira issue. Forcing a 2.303.x dep is causing some extra work in https://github.com/jenkinsci/bom/pull/1168 and may be undesirable in https://github.com/jenkinsci/git-plugin/pull/1274#discussion_r881016170 and https://github.com/jenkinsci/workflow-multibranch-plugin/pull/180.
