### PR TITLE
[JENKINS-69135] Add a "Versions to include" field to the Global Library Cache feature

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -210,7 +210,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
             shouldCache = false;
         }
 
-        if(shouldCache) {
+        if(shouldCache && cachingConfiguration.isIncluded(version)) {
             retrieveLock.readLock().lockInterruptibly();
             try {
                 CacheStatus cacheStatus = getCacheStatus(cachingConfiguration, versionCacheDir);

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -158,37 +158,4 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
             return FormValidation.ok("The cache dir was deleted successfully.");
         }
     }
-
-    /**
-     * Method can be called from an external source to delete cache of a particular version of the shared library
-     * Example: delete cache from through pipeline script once the build is successful
-     * @param jenkinsLibrary Name of the shared library
-     * @param version Name of the version to delete the cache
-     * @throws IOException
-     * @throws InterruptedException
-     */
-    public static void deleteLibraryCacheForBranch(String jenkinsLibrary, String version) throws IOException, InterruptedException {
-        if (LibraryCachingConfiguration.getGlobalLibrariesCacheDir().exists()) {
-            for (FilePath libraryNamePath : LibraryCachingConfiguration.getGlobalLibrariesCacheDir().list("*-name.txt")) {
-                String cacheName;
-                try (InputStream stream = libraryNamePath.read()) {
-                    cacheName = IOUtils.toString(stream, StandardCharsets.UTF_8);
-
-                    if (cacheName.equals(jenkinsLibrary)) {
-                        FilePath libraryCachePath = LibraryCachingConfiguration.getGlobalLibrariesCacheDir()
-                                .child(libraryNamePath.getName().replace("-name.txt", ""));
-                        ReentrantReadWriteLock retrieveLock = LibraryAdder.getReadWriteLockFor(libraryCachePath.getName());
-                        if (retrieveLock.writeLock().tryLock(10, TimeUnit.SECONDS)) {
-                            try {
-                                libraryCachePath.deleteRecursive();
-                                libraryNamePath.delete();
-                            } finally {
-                                retrieveLock.writeLock().unlock();
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
@@ -31,6 +31,9 @@ THE SOFTWARE.
     <f:entry title="${%Versions to exclude}" field="excludedVersionsStr">
         <f:textbox />
     </f:entry>
+     <f:entry title="${%Versions to include}" field="includedVersionsStr">
+        <f:textbox />
+     </f:entry>
     <j:if test="${h.hasPermission(app.ADMINISTER)}">
         <f:entry title="${%Force clear cache}" field="forceDelete">
           <f:checkbox/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-includedVersionsStr.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-includedVersionsStr.html
@@ -1,0 +1,6 @@
+<div>
+    Space separated list of versions to include to allow caching via substring search using .contains() method. Ex: "release/ master".
+</div>
+<div>
+    Note: Excluded versions will always take precedence over included versions
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -420,7 +420,7 @@ public class LibraryAdderTest {
                 new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
         globalLib.setDefaultVersion("master");
         globalLib.setImplicit(true);
-        globalLib.setCachingConfiguration(new LibraryCachingConfiguration(60, ""));
+        globalLib.setCachingConfiguration(new LibraryCachingConfiguration(60, "", ""));
         GlobalLibraries.get().setLibraries(Collections.singletonList(globalLib));
         // Create a folder library with the same name and which is also set up to enable caching.
         sampleRepo2.write("vars/folderLibVar.groovy", "def call() { jenkins.model.Jenkins.get().setSystemMessage('folder library') }");
@@ -430,7 +430,7 @@ public class LibraryAdderTest {
                 new SCMSourceRetriever(new GitSCMSource(null, sampleRepo2.toString(), "", "*", "", true)));
         folderLib.setDefaultVersion("master");
         folderLib.setImplicit(true);
-        folderLib.setCachingConfiguration(new LibraryCachingConfiguration(60, ""));
+        folderLib.setCachingConfiguration(new LibraryCachingConfiguration(60, "", ""));
         Folder f = r.jenkins.createProject(Folder.class, "folder1");
         f.getProperties().add(new FolderLibraries(Collections.singletonList(folderLib)));
         // Create a job that uses the folder library, which will take precedence over the global library, since they have the same name.
@@ -493,7 +493,7 @@ public class LibraryAdderTest {
                 new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
         config.setDefaultVersion("master");
         config.setImplicit(true);
-        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null,null));
         GlobalLibraries.get().getLibraries().add(config);
         WorkflowJob p1 = r.createProject(WorkflowJob.class);
         WorkflowJob p2 = r.createProject(WorkflowJob.class);

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
@@ -59,7 +59,7 @@ public class LibraryCachingCleanupTest {
                 new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
         config.setDefaultVersion("master");
         config.setImplicit(true);
-        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null, null));
         GlobalLibraries.get().getLibraries().add(config);
         // Run build and check that cache gets created.
         WorkflowJob p = r.createProject(WorkflowJob.class);

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -190,6 +190,7 @@ public class LibraryCachingConfigurationTest {
         assertFalse(substringVersionConfig.isExcluded(null));
     }
 
+    @Issue("JENKINS-69135") //"Versions to include" feature for caching
     @Test
     @WithoutJenkins
     public void isIncluded() {
@@ -204,6 +205,16 @@ public class LibraryCachingConfigurationTest {
 
         assertTrue(substringVersionConfig.isIncluded(SUBSTRING_INCLUDED_VERSIONS_1));
         assertTrue(substringVersionConfig.isIncluded(SUBSTRING_INCLUDED_VERSIONS_2));
+
+        assertFalse(nullVersionConfig.isIncluded(""));
+        assertFalse(oneVersionConfig.isIncluded(""));
+        assertFalse(multiVersionConfig.isIncluded(""));
+        assertFalse(substringVersionConfig.isIncluded(""));
+
+        assertFalse(nullVersionConfig.isIncluded(null));
+        assertFalse(oneVersionConfig.isIncluded(null));
+        assertFalse(multiVersionConfig.isIncluded(null));
+        assertFalse(substringVersionConfig.isIncluded(null));
 
     }
 
@@ -234,6 +245,9 @@ public class LibraryCachingConfigurationTest {
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
     }
 
+    //Test similar substrings in "Versions to include" & "Versions to exclude"
+    //Exclusion takes precedence
+    @Issue("JENKINS-69135") //"Versions to include" feature for caching
     @Test
     public void clearCacheConflict() throws Exception {
         sampleRepo.init();
@@ -255,6 +269,7 @@ public class LibraryCachingConfigurationTest {
         LibrariesAction action = b.getAction(LibrariesAction.class);
         LibraryRecord record = action.getLibraries().get(0);
         FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child(record.getDirectoryName());
+        // Cache should not get created since the version is included in "Versions to exclude"
         assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -61,31 +61,57 @@ public class LibraryCachingConfigurationTest {
     private static int NO_REFRESH_TIME_MINUTES = 0;
 
     private static String NULL_EXCLUDED_VERSION = null;
+    private static String NULL_INCLUDED_VERSION = null;
+
     private static String ONE_EXCLUDED_VERSION = "branch-1";
 
+    private static String ONE_INCLUDED_VERSION = "branch-1i";
+
+
     private static String MULTIPLE_EXCLUDED_VERSIONS_1 = "main";
+
+    private static String MULTIPLE_INCLUDED_VERSIONS_1 = "master";
+
     private static String MULTIPLE_EXCLUDED_VERSIONS_2 = "branch-2";
+
+    private static String MULTIPLE_INCLUDED_VERSIONS_2 = "branch-2i";
+
     private static String MULTIPLE_EXCLUDED_VERSIONS_3 = "branch-3";
+    private static String MULTIPLE_INCLUDED_VERSIONS_3 = "branch-3i";
+
 
     private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature/test-substring-exclude";
+
+    private static String SUBSTRING_INCLUDED_VERSIONS_1 = "feature_include/test-substring";
+
     private static String SUBSTRING_EXCLUDED_VERSIONS_2 = "test-other-substring-exclude";
+    private static String SUBSTRING_INCLUDED_VERSIONS_2 = "test-other-substring-include";
+
 
     private static String MULTIPLE_EXCLUDED_VERSIONS =
         MULTIPLE_EXCLUDED_VERSIONS_1 + " " +
         MULTIPLE_EXCLUDED_VERSIONS_2 + " " +
         MULTIPLE_EXCLUDED_VERSIONS_3;
 
+    private static String MULTIPLE_INCLUDED_VERSIONS =
+            MULTIPLE_INCLUDED_VERSIONS_1 + " " +
+            MULTIPLE_INCLUDED_VERSIONS_2 + " " +
+            MULTIPLE_INCLUDED_VERSIONS_3;
+
     private static String SUBSTRING_EXCLUDED_VERSIONS =
         "feature/ other-substring";
+
+    private static String SUBSTRING_INCLUDED_VERSIONS =
+            "feature_include/ other-substring";
 
     private static String NEVER_EXCLUDED_VERSION = "never-excluded-version";
 
     @Before
     public void createCachingConfiguration() {
-        nullVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, NULL_EXCLUDED_VERSION);
-        oneVersionConfig = new LibraryCachingConfiguration(NO_REFRESH_TIME_MINUTES, ONE_EXCLUDED_VERSION);
-        multiVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, MULTIPLE_EXCLUDED_VERSIONS);
-        substringVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, SUBSTRING_EXCLUDED_VERSIONS);
+        nullVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, NULL_EXCLUDED_VERSION, NULL_INCLUDED_VERSION);
+        oneVersionConfig = new LibraryCachingConfiguration(NO_REFRESH_TIME_MINUTES, ONE_EXCLUDED_VERSION, ONE_INCLUDED_VERSION);
+        multiVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, MULTIPLE_EXCLUDED_VERSIONS, MULTIPLE_INCLUDED_VERSIONS);
+        substringVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, SUBSTRING_EXCLUDED_VERSIONS, SUBSTRING_INCLUDED_VERSIONS);
     }
 
     @Issue("JENKINS-66045") // NPE getting excluded versions
@@ -127,6 +153,15 @@ public class LibraryCachingConfigurationTest {
 
     @Test
     @WithoutJenkins
+    public void getIncludedVersionsStr() {
+        assertThat(nullVersionConfig.getIncludedVersionsStr(), is(NULL_INCLUDED_VERSION));
+        assertThat(oneVersionConfig.getIncludedVersionsStr(), is(ONE_INCLUDED_VERSION));
+        assertThat(multiVersionConfig.getIncludedVersionsStr(), is(MULTIPLE_INCLUDED_VERSIONS));
+        assertThat(substringVersionConfig.getIncludedVersionsStr(), is(SUBSTRING_INCLUDED_VERSIONS));
+    }
+
+    @Test
+    @WithoutJenkins
     public void isExcluded() {
         assertFalse(nullVersionConfig.isExcluded(NULL_EXCLUDED_VERSION));
         assertFalse(nullVersionConfig.isExcluded(""));
@@ -156,6 +191,23 @@ public class LibraryCachingConfigurationTest {
     }
 
     @Test
+    @WithoutJenkins
+    public void isIncluded() {
+        assertFalse(nullVersionConfig.isIncluded(NULL_INCLUDED_VERSION));
+        assertFalse(nullVersionConfig.isIncluded(""));
+
+        assertTrue(oneVersionConfig.isIncluded(ONE_INCLUDED_VERSION));
+
+        assertTrue(multiVersionConfig.isIncluded(MULTIPLE_INCLUDED_VERSIONS_1));
+        assertTrue(multiVersionConfig.isIncluded(MULTIPLE_INCLUDED_VERSIONS_2));
+        assertTrue(multiVersionConfig.isIncluded(MULTIPLE_INCLUDED_VERSIONS_3));
+
+        assertTrue(substringVersionConfig.isIncluded(SUBSTRING_INCLUDED_VERSIONS_1));
+        assertTrue(substringVersionConfig.isIncluded(SUBSTRING_INCLUDED_VERSIONS_2));
+
+    }
+
+    @Test
     public void clearCache() throws Exception {
         sampleRepo.init();
         sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
@@ -165,7 +217,7 @@ public class LibraryCachingConfigurationTest {
                 new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
         config.setDefaultVersion("master");
         config.setImplicit(true);
-        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null, "master"));
         GlobalLibraries.get().getLibraries().add(config);
         // Run build and check that cache gets created.
         WorkflowJob p = r.createProject(WorkflowJob.class);
@@ -178,6 +230,31 @@ public class LibraryCachingConfigurationTest {
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), anExistingFile());
         // Clear the cache. TODO: Would be more realistic to set up security and use WebClient.
         ExtensionList.lookupSingleton(LibraryCachingConfiguration.DescriptorImpl.class).doClearCache("library", false);
+        assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
+        assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
+    }
+
+    @Test
+    public void clearCacheConflict() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration config = new LibraryConfiguration("library",
+                new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        config.setDefaultVersion("master");
+        config.setImplicit(true);
+        // Same version specified in both include and exclude version
+        //Exclude takes precedence
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, "master", "master"));
+        GlobalLibraries.get().getLibraries().add(config);
+        // Run build and check that cache gets created.
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("foo()", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        LibrariesAction action = b.getAction(LibrariesAction.class);
+        LibraryRecord record = action.getLibraries().get(0);
+        FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child(record.getDirectoryName());
         assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
         assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -71,7 +71,7 @@ public class ResourceStepTest {
         initFixedContentLibrary();
         
         LibraryConfiguration libraryConfig =  new LibraryConfiguration("stuff", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(0, ""));
+        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(0, "",""));
         GlobalLibraries.get().setLibraries(Collections.singletonList(libraryConfig));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 
@@ -92,7 +92,7 @@ public class ResourceStepTest {
         initFixedContentLibrary();
         
         LibraryConfiguration libraryConfig =  new LibraryConfiguration("stuff", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(0, "test_unused other"));
+        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(0, "test_unused other", null));
         GlobalLibraries.get().setLibraries(Collections.singletonList(libraryConfig));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 
@@ -114,7 +114,7 @@ public class ResourceStepTest {
         initFixedContentLibrary();
         
         LibraryConfiguration libraryConfig =  new LibraryConfiguration("stuff", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(60, "test_unused other"));
+        libraryConfig.setCachingConfiguration(new LibraryCachingConfiguration(60, "test_unused other", ""));
         GlobalLibraries.get().setLibraries(Collections.singletonList(libraryConfig));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 


### PR DESCRIPTION
You can now specify versions to be included for caching. This allows only those specific versions to be cached. This feature can be very useful when there are many versions and you want only one or more of them to be cached. It has the same working mechanism as that of the "Versions to exclude". One thing to be noted is that "Versions to exclude" will always take precedence over "Versions to include" for similar substrings mentioned in both at the same time. 

This is pertaining to the Jenkins feature request: [JENKINS-69135](https://issues.jenkins.io/browse/JENKINS-69135)

Another important feature as per the PR: https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/4, to delete only a specific version from cache, was tested in collaboration with "Versions to include". The branch for the same: [Versions to include + delete specific version](https://github.com/AnishaGharat/pipeline-groovy-lib-plugin/tree/feature/delete-specific-cache-version-remotely). 

Bonus Points: The cache deletion method for a specific version can be invoked remotely such that:
`final cacheControl = new LibraryCachingConfiguration.DescriptorImpl();`
 `cacheControl.doClearCache(libraryName, branchName, false);`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
