### PR TITLE
Adapt test for git plugin 5.0

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -85,7 +85,11 @@ public class LibraryStepTest {
             null, null, Collections.<GitSCMExtension>emptyList())));
         s.setChangelog(false);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
-        snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
+        if (r.jenkins.get().getPlugin("git").getWrapper().getVersion().startsWith("4.")) {
+            snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
+        } else {
+            snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM(scmGit(branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]))");
+        }
     }
 
     @Test public void vars() throws Exception {


### PR DESCRIPTION
## Adapt test for git plugin 5.0

Git plugin 5.0 will require Java 11 and will add symbols to improve the Pipeline syntax editing experience.  The test being modified in this pull request checks the specific syntax of the Pipeline snippet syntax generator.  Adapt the test to check for current syntax with git plugin 4.x releases and for new syntax with any other releases.

* https://github.com/jenkinsci/git-client-plugin/pull/939 is the git client plugin pull request that prepares git client plugin 4.0.0.  It will require Java 11 and will upgrade from JGit 5.13.1 to JGit 6.4.0.
* https://github.com/jenkinsci/bom/pull/1619 is the bom draft pull request that confirms git client plugin 4.0.0 pre-release works in the plugin bom.
* https://github.com/jenkinsci/git-plugin/pull/1367 is the git plugin pull request that prepares git plugin 5.0.0.  It will require Java 11.
* https://github.com/jenkinsci/bom/pull/1624 is the bom draft pull request that tests git plugin 5.0.0 works in the plugin bom.
* https://github.com/jenkinsci/git-plugin/pull/1373 is the git plugin pull request that relies on https://github.com/jenkinsci/git-plugin/pull/1367 and adds symbols to the git plugin.
* https://github.com/jenkinsci/bom/pull/1625 is the bom draft pull request that tests git plugin 5.0.0 with added symbols works in the plugin bom.  It detected this test failure when run with git plugin 5.0.0 pre-release.

It would be nice to have a new release of this plugin ready to go at (or before) the release of git plugin 5.0.0 so that the bom can include git plugin 5.0.0 soon after the release of git plugin 5.0.0.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
