### PR TITLE
Suppressing `FolderLibrariesTest.classCastException` on Windows

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
@@ -32,6 +32,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.google.common.collect.ImmutableMap;
+import hudson.Functions;
 import hudson.model.Item;
 import hudson.model.Result;
 import hudson.plugins.git.GitSCM;
@@ -54,6 +55,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -188,6 +190,7 @@ public class FolderLibrariesTest {
 
     @Issue("JENKINS-43019")
     @Test public void classCastException() throws Exception {
+        assumeFalse("Too slow, prone to timing out before getting to build #51", Functions.isWindows());
         sampleRepo1.init();
         sampleRepo1.write("src/pkg/Obj.groovy", "package pkg; public class Obj implements Serializable {public Obj() {}}");
         sampleRepo1.write("vars/objs.groovy", "@groovy.transform.Field final pkg.Obj OBJ = new pkg.Obj()");


### PR DESCRIPTION
Test from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/33 observed to time out in https://github.com/jenkinsci/pipeline-groovy-lib-plugin/pull/55/checks?check_run_id=11727884826, probably also https://github.com/jenkinsci/pipeline-groovy-lib-plugin/runs/7320736530. Should suffice to run this on Linux, where it is far faster, to prevent regression.