### PR TITLE
[JENKINS-69573] retrieve sources in tmpdir and rename

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -239,8 +239,19 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                             
                         if (retrieve) {
                             listener.getLogger().println("Caching library " + name + "@" + version);                            
-                            versionCacheDir.mkdirs();
-                            retriever.retrieve(name, version, changelog, versionCacheDir, run, listener);
+                            FilePath tmpVersionCacheDir = new FilePath(LibraryCachingConfiguration.getGlobalLibrariesCacheDir(), record.getDirectoryName() + "@tmp");
+                            try {
+                                if (tmpVersionCacheDir.exists()) {
+                                    tmpVersionCacheDir.deleteRecursive();
+                                }
+                                tmpVersionCacheDir.mkdirs();
+                                retriever.retrieve(name, version, changelog, tmpVersionCacheDir, run, listener);
+                                tmpVersionCacheDir.renameTo(versionCacheDir);
+                            } finally {
+                                if (tmpVersionCacheDir.exists()) {
+                                    tmpVersionCacheDir.deleteRecursive();
+                                }
+                            }
                         }
                         retrieveLock.readLock().lock();
                     } finally {


### PR DESCRIPTION
When the retrieve from the scm of a library into the cache fails, we end up with a corrupted cache directory. All following pipelines using this library will fail until the cache has expired.

This fix will create a temporary directory into which the library is retrieved. Afterwards the directory is renamed to the actual cache directory (which is more or less atomic).

[JENKINS-69573](https://issues.jenkins.io/browse/JENKINS-69573)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
