### PR TITLE
Exclude HTMLUnit failing assertion in Jenkins 2.400 and later

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 17, jenkins: '2.400'],
     [platform: 'windows', jdk: 11],
 ])

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -33,6 +33,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.util.VersionNumber;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -77,7 +78,10 @@ public class LibraryStepTest {
         scmSource.setCredentialsId(""); // TODO the setter ought to use fixEmpty
         s.setRetriever(new SCMSourceRetriever(scmSource));
         s.setChangelog(true);
-        r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
+        // TODO Assertion fails with 2.400 and later due to outdated JavaScript support in HTMLUnit
+        if (r.jenkins.get().getVersion().isOlderThan(new VersionNumber("2.400"))) {
+            r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
+        }
         // TODO uninstantiate works but SnippetizerTester.assertRoundTrip fails due to differing SCMSource.id values
         assertEquals("library identifier: 'foo@master', retriever: modernSCM([$class: 'GitSCMSource', credentialsId: '', remote: 'https://nowhere.net/', traits: [gitBranchDiscovery()]])", Snippetizer.object2Groovy(s));
         s.setRetriever(new SCMRetriever(new GitSCM(Collections.singletonList(new UserRemoteConfig("https://nowhere.net/", null, null, null)),


### PR DESCRIPTION
## Exclude HTMLUnit failing assertion in Jenkins 2.400 and later

https://github.com/jenkinsci/bom/pull/1959#issuecomment-1507906453 explains that the modernization of hetero-list.js has inserted JavaScript that the HTMLUnit JavaScript engine does not understand.  That causes the test to fail with an HTTP 500 error when the specific assertion is executed.

Do not execute the failing assertion on Jenkins 2.400 and later.  Excluding the failing assertion is a simple short-term workaround for the larger problem that is described by @basil in https://github.com/jenkinsci/jenkins-test-harness/issues/569#issue-1661461679

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
