### PR TITLE
Remove git plugin 4.x test code

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -85,11 +85,7 @@ public class LibraryStepTest {
             null, null, Collections.<GitSCMExtension>emptyList())));
         s.setChangelog(false);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
-        if (r.jenkins.get().getPlugin("git").getWrapper().getVersion().startsWith("4.")) {
-            snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
-        } else {
-            snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM(scmGit(branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]))");
-        }
+        snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM(scmGit(branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]))");
     }
 
     @Test public void vars() throws Exception {


### PR DESCRIPTION
## Remove git plugin 4.x test code

Git plugin 5.0.0 has been provided since bom 1763.v092b_8980a_f5e.  No need to include the special case for git plugin 4.x since this code will never be run with git plugin 4.x.

Moves forward from 01b9885ff78ebbbb18e20083eaab0a190525eb78

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
