### PR TITLE
[JENKINS-72440] Default library step changelog to global configuration settings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -91,7 +91,7 @@ public class LibraryStep extends AbstractStepImpl {
     private static final Logger LOGGER = Logger.getLogger(LibraryStep.class.getName());
 
     private final String identifier;
-    private Boolean changelog = true;
+    private Boolean changelog;
     private LibraryRetriever retriever;
 
     @DataBoundConstructor public LibraryStep(String identifier) {


### PR DESCRIPTION
[JENKINS-72440](https://issues.jenkins.io/browse/JENKINS-72440)

### Testing done

* Stand up a controller
* Configure a "Global Pipeline Library"
    * Uncheck "Include @Library changes in job recent changes"
    * Ensure "Load implicitly" is not checked
* Create two Pipelines
    * First pipeline uses the `@Library` annotation to load the above library and use a test step
    * Second pipeline uses the `library` step to do the same

**Defaults**

* Run the pipelines
* Make a new commit to the shared library repository
* Run the pipelines again

--> The second run of both pipelines shows NO changes

**Global configuration is the default**

* Reconfigure the global pipeline library
    * Check "Include @Library changes in job recent changes"
* Make a new commit to the shared library repository
* Run the pipelines again

--> The new run of both pipelines shows changes

**Library step overrides / takes precedence**

* Reconfigure the pipeline with the `library` step:
    * Add the option `changelog: false`
* Make a new commit to the shared library repository
* Run the pipelines again

--> The new run of the pipeline with the annoation shows changes
--> The new run of the pipeline with the `library` step shows NO changes

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```