### PR TITLE
[JENKINS-63355] Prevent NPEs when library name is not provided

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -120,6 +120,10 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
             boolean kindTrusted = kind.isTrusted();
             for (LibraryConfiguration cfg : kind.forJob(build.getParent(), libraryVersions)) {
                 String name = cfg.getName();
+                if (name == null) {
+                    continue;
+                }
+
                 if (!cfg.isImplicit() && !libraryVersions.containsKey(name)) {
                     continue; // not using this one at all
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -70,6 +70,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
      * Library name.
      * Should match {@link Library#value}, up to the first occurrence of {@code @}, if any.
      */
+    @CheckForNull
     public String getName() {
         return name;
     }
@@ -173,6 +174,9 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
 
         @RequirePOST
         public FormValidation doCheckDefaultVersion(@AncestorInPath Item context, @QueryParameter String defaultVersion, @QueryParameter boolean implicit, @QueryParameter boolean allowVersionOverride, @QueryParameter String name) {
+            if (name.isEmpty()) {
+                return FormValidation.error("You must enter a name.");
+            }
             if (defaultVersion.isEmpty()) {
                 if (implicit) {
                     return FormValidation.error("If you load a library implicitly, you must specify a default version.");
@@ -184,7 +188,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
             } else {
                 for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
                     for (LibraryConfiguration config : resolver.fromConfiguration(Stapler.getCurrentRequest())) {
-                        if (config.getName().equals(name)) {
+                        if (name.equals(config.getName())) {
                             return config.getRetriever().validateVersion(name, defaultVersion, context);
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -168,6 +168,9 @@ public class LibraryStep extends AbstractStepImpl {
         @Override protected LoadedClasses run() throws Exception {
             String[] parsed = LibraryAdder.parse(step.identifier);
             String name = parsed[0], version = parsed[1];
+            if (name == null) {
+                throw new AbortException("No library name provided");
+            }
             boolean trusted = false;
             Boolean changelog = step.getChangelog();
             LibraryCachingConfiguration cachingConfiguration = null;
@@ -177,7 +180,7 @@ public class LibraryStep extends AbstractStepImpl {
             if (retriever == null) {
                 for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
                     for (LibraryConfiguration cfg : resolver.forJob(run.getParent(), Collections.singletonMap(name, version))) {
-                        if (cfg.getName().equals(name)) {
+                        if (name.equals(cfg.getName())) {
                             retriever = cfg.getRetriever();
                             trusted = resolver.isTrusted();
                             version = cfg.defaultedVersion(version);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/config.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="identifier" title="${%Name and optional version}">
-        <f:textbox/>
+        <f:textbox clazz="required"/>
     </f:entry>
     <f:entry field="changelog" title="${%Include recent changes in jobs}">
         <f:checkbox default="true"/>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -338,4 +338,19 @@ public class LibraryStepTest {
         r.assertLogContains("/lib/java", b);
         r.assertLogContains("/pipeline/java", b);
     }
+
+    @Issue("JENKINS-63355")
+    @Test public void emptyNameLibrariesAreSkipped() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/x.groovy", "def call() {echo 'ran library'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(List.of(
+            new LibraryConfiguration("stuff", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true))),
+            new LibraryConfiguration("", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))
+        ));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("library 'stuff@master'; x()", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+    }
 }


### PR DESCRIPTION
[JENKINS-63355](https://issues.jenkins.io/browse/JENKINS-63355) Prevent NPEs in cases where the library name is not provided

### Testing done

* Start a controller
* Add a Global Pipeline Library pointing to a repo with a hello world step.
* Create a Folder, use defaults
* Create a hello world pipeline that uses the above library via the library step. e.g. library "test-steps"; helloWorld()
* Run the pipeline to confirm that it succeeds
* Configure Folder
    * Find "Pipeline Libraries" section and click "Add"
    * Ignore the error about the library name and click "Save"
* Run the pipeline again
* Make sure that the pipeline succeeds

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```