### PR TITLE
[JENKINS-69573] Delete `versionCacheDir` if retrieve fails

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -244,7 +244,14 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                         if (retrieve) {
                             listener.getLogger().println("Caching library " + name + "@" + version);
                             versionCacheDir.mkdirs();
-                            retriever.retrieve(name, version, changelog, versionCacheDir, run, listener);
+                            // try to retrieve the library and delete the versionCacheDir if it fails
+                            try {
+                                retriever.retrieve(name, version, changelog, versionCacheDir, run, listener);
+                            } catch (Exception e) {
+                                listener.getLogger().println("Failed to cache library " + name + "@" + version + ". Error message: " + e.getMessage() + ". Cleaning up cache directory.");
+                                versionCacheDir.deleteRecursive();
+                                throw e;
+                            }
                         }
                         retrieveLock.readLock().lock();
                     } finally {


### PR DESCRIPTION
This PR cleans the cache directory if anything happens to fail during the retrieval process. Leaving the cache directory in an empty state breaks any subsequent retrieval attempts.

### Testing done

Testing was done, somewhat unorthodox, manually using the following snippet after the line

```java
                                retriever.retrieve(name, version, changelog, versionCacheDir, run, listener);
```

Testing snippet...

```java
                                // if file called /tmp/fail exists, then the library retrieval failed
                                if (new File("/tmp/failme").exists()) {
                                    throw new Exception("Library retrieval failed");
                                }
```

Then I tested by adding and then removing the `/tmp/failme` file on the server.

Test build 1 - caching:

```mono
Loading library platform-library@main
Caching library platform-library@main
Attempting to resolve main from remote references...
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git ls-remote -h -- https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Found match: refs/heads/main revision 0dd48d00789138d95f93ddbd8a542029bbb104aa
Selected Git installation does not exist. Using Default
The recommended git tool is: NONE
using credential github-token-ro
 > git rev-parse --resolve-git-dir /var/jenkins_home/workspace/test-p@libs/6e0de9cdfb00bd884bf1879d962f10d0b1dcfbbfd73ad9bad58c44e0faca6105/.git # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Fetching without tags
Fetching upstream changes from https://github.com/tsmp-falcon-platform/jenkins-library
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git fetch --no-tags --force --progress -- https://github.com/tsmp-falcon-platform/jenkins-library +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 0dd48d00789138d95f93ddbd8a542029bbb104aa (main)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
Commit message: "TSM-1090: add emailext util to manage templates (#6)"
 > git rev-list --no-walk 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
[Pipeline] Start of Pipeline
[Pipeline] echo
Hi
[Pipeline] End of Pipeline
Finished: SUCCESS
```

Test build 2 - cached:

```mono
Loading library platform-library@main
Library platform-library@main is cached. Copying from home.
[Pipeline] Start of Pipeline
[Pipeline] echo
Hi
[Pipeline] End of Pipeline
Finished: SUCCESS
``` 

Test build 3 - failing (adding `/tmp/failme`):

```mono
Loading library platform-library@main
Library platform-library@main is due for a refresh after 1 minutes, clearing.
Caching library platform-library@main
Attempting to resolve main from remote references...
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git ls-remote -h -- https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Found match: refs/heads/main revision 0dd48d00789138d95f93ddbd8a542029bbb104aa
Selected Git installation does not exist. Using Default
The recommended git tool is: NONE
using credential github-token-ro
 > git rev-parse --resolve-git-dir /var/jenkins_home/workspace/test-p@libs/6e0de9cdfb00bd884bf1879d962f10d0b1dcfbbfd73ad9bad58c44e0faca6105/.git # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Fetching without tags
Fetching upstream changes from https://github.com/tsmp-falcon-platform/jenkins-library
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git fetch --no-tags --force --progress -- https://github.com/tsmp-falcon-platform/jenkins-library +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 0dd48d00789138d95f93ddbd8a542029bbb104aa (main)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
Commit message: "TSM-1090: add emailext util to manage templates (#6)"
 > git rev-list --no-walk 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
Failed to cache library platform-library@main. Error message: Library retrieval failed. Cleaning up cache directory.
java.lang.IllegalMonitorStateException: attempt to unlock read lock, not locked by current thread
	at java.base/java.util.concurrent.locks.ReentrantReadWriteLock$Sync.unmatchedUnlockException(ReentrantReadWriteLock.java:448)
	at java.base/java.util.concurrent.locks.ReentrantReadWriteLock$Sync.tryReleaseShared(ReentrantReadWriteLock.java:432)
	at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.releaseShared(AbstractQueuedSynchronizer.java:1094)
	at java.base/java.util.concurrent.locks.ReentrantReadWriteLock$ReadLock.unlock(ReentrantReadWriteLock.java:897)
	at org.jenkinsci.plugins.workflow.libs.LibraryAdder.retrieve(LibraryAdder.java:272)
	at org.jenkinsci.plugins.workflow.libs.LibraryAdder.add(LibraryAdder.java:151)
	at org.jenkinsci.plugins.workflow.libs.LibraryDecorator$1.call(LibraryDecorator.java:125)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1087)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:624)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:602)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:579)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:323)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:293)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox$Scope.parse(GroovySandbox.java:163)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:190)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:175)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:635)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:581)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:335)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:443)
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: Loading libraries failed

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:309)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1107)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:624)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:602)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:579)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:323)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:293)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox$Scope.parse(GroovySandbox.java:163)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:190)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:175)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:635)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:581)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:335)
	at hudson.model.ResourceController.execute(ResourceController.java:101)
	at hudson.model.Executor.run(Executor.java:443)
Finished: FAILURE
```

Test build 4 - caching again (after removing `/tmp/failme`):

```mono
Loading library platform-library@main
Caching library platform-library@main
Attempting to resolve main from remote references...
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git ls-remote -h -- https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Found match: refs/heads/main revision 0dd48d00789138d95f93ddbd8a542029bbb104aa
Selected Git installation does not exist. Using Default
The recommended git tool is: NONE
using credential github-token-ro
 > git rev-parse --resolve-git-dir /var/jenkins_home/workspace/test-p@libs/6e0de9cdfb00bd884bf1879d962f10d0b1dcfbbfd73ad9bad58c44e0faca6105/.git # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url https://github.com/tsmp-falcon-platform/jenkins-library # timeout=10
Fetching without tags
Fetching upstream changes from https://github.com/tsmp-falcon-platform/jenkins-library
 > git --version # timeout=10
 > git --version # 'git version 2.39.3'
using GIT_ASKPASS to set credentials Github Token for reading bundles
 > git fetch --no-tags --force --progress -- https://github.com/tsmp-falcon-platform/jenkins-library +refs/heads/*:refs/remotes/origin/* # timeout=10
Checking out Revision 0dd48d00789138d95f93ddbd8a542029bbb104aa (main)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
Commit message: "TSM-1090: add emailext util to manage templates (#6)"
 > git rev-list --no-walk 0dd48d00789138d95f93ddbd8a542029bbb104aa # timeout=10
[Pipeline] Start of Pipeline
[Pipeline] echo
Hi
[Pipeline] End of Pipeline
Finished: SUCCESS
```

Test build 5 - cached:

```mono
Loading library platform-library@main
Library platform-library@main is cached. Copying from home.
[Pipeline] Start of Pipeline
[Pipeline] echo
Hi
[Pipeline] End of Pipeline
Finished: SUCCESS
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
