### PR TITLE
CasC globalLibraries Demonstrating weird warning message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,5 +221,10 @@
             <version>1.10.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/JCasCGlobalLibrariesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/JCasCGlobalLibrariesTest.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.workflow.libs;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.LoggerRule;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIn.in;
+import static org.hamcrest.core.IsNot.not;
+
+public class JCasCGlobalLibrariesTest {
+
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+    public LoggerRule logging = new LoggerRule();
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(logging.record(Logger.getLogger("io.jenkins.plugins.casc.BaseConfigurator"), Level.INFO)
+                    .capture(2048))
+            .around(j);
+
+    @Test
+    @ConfiguredWithCode("JCasCGlobalLibrariesTest.yml")
+    public void isBaseConfiguratorComplainingAboutOwner() {
+        //WARNING i.j.p.casc.BaseConfigurator#createAttribute: Can't handle class jenkins.plugins.git.GitSCMSource#owner: type is abstract but not Describable.
+        assertThat("Can't handle class jenkins.plugins.git.GitSCMSource#owner: type is abstract but not Describable.",
+                not(in(logging.getMessages())
+        ));
+    }
+}

--- a/src/test/resources/JCasCGlobalLibrariesTest.yml
+++ b/src/test/resources/JCasCGlobalLibrariesTest.yml
@@ -1,0 +1,15 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - defaultVersion: "dev"
+        includeInChangesets: false
+        name: "cloudbees-shared-library"
+        retriever:
+          modernSCM:
+            clone: true
+            scm:
+              git:
+                credentialsId:
+                remote:
+                traits:
+                  - "gitBranchDiscovery"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Found a weird warning message when configuring global libraries with JCasC and wanted to show an example.
Also this plugin weirdly has no JCasC tests at all.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
