### PR TITLE
[JENKINS-73769] account for empty libraries or changed library path 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -70,7 +70,7 @@ public final class LibraryRecord {
         this.changelog = changelog;
         this.cachingConfiguration = cachingConfiguration;
         logString = this.name + "@" + this.version;
-        if (StringUtils.isNotBlank(libraryPath) && libraryPath != ".") {
+        if (StringUtils.isNotBlank(libraryPath) && !libraryPath.equals(".")) {
             this.libraryPath = libraryPath;
             this.directoryName = directoryNameFor(name, version, String.valueOf(trusted), source, libraryPath);
             logString += " from libraryPath: " + libraryPath;

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.libs;
 
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
@@ -70,14 +71,23 @@ public final class LibraryRecord {
         this.changelog = changelog;
         this.cachingConfiguration = cachingConfiguration;
         logString = this.name + "@" + this.version;
-        if (StringUtils.isNotBlank(libraryPath) && !libraryPath.equals(".")) {
+        if (onTheRoadToNowhere(libraryPath)) {
+            this.libraryPath = "";
+            this.directoryName = directoryNameFor(name, version, String.valueOf(trusted), source);
+        } else {
             this.libraryPath = libraryPath;
             this.directoryName = directoryNameFor(name, version, String.valueOf(trusted), source, libraryPath);
             logString += " from libraryPath: " + libraryPath;
-        } else {
-            this.libraryPath = "";
-            this.directoryName = directoryNameFor(name, version, String.valueOf(trusted), source);
         }
+    }
+
+    private boolean onTheRoadToNowhere(String libraryPath) {
+        if (StringUtils.isBlank(libraryPath)) {
+            return true;
+        }
+        String currentDir = Paths.get("").toAbsolutePath().normalize().toString();
+        String libraryDir = Paths.get(libraryPath).toAbsolutePath().normalize().toString();
+        return currentDir.equals(libraryDir);
     }
 
     @Exported

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -77,7 +77,7 @@ public final class LibraryRecord {
         } else {
             this.libraryPath = libraryPath;
             this.directoryName = directoryNameFor(name, version, String.valueOf(trusted), source, libraryPath);
-            logString += " from libraryPath: " + libraryPath;
+            logString += ":" + libraryPath;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -218,7 +218,11 @@ public class LibraryStep extends Step {
                 verifyRevision(((SingleSCMSource) ((SCMSourceRetriever) retriever).getScm()).getScm(), name, run, listener);
             }
 
-            LibraryRecord record = new LibraryRecord(name, version, trusted, changelog, cachingConfiguration, source);
+            String libraryPath = null;
+            if (retriever instanceof SCMBasedRetriever) {
+                libraryPath = ((SCMBasedRetriever) retriever).getLibraryPath();
+            }
+            LibraryRecord record = new LibraryRecord(name, version, trusted, changelog, cachingConfiguration, source, libraryPath);
             LibrariesAction action = run.getAction(LibrariesAction.class);
             if (action == null) {
                 action = new LibrariesAction(Lists.newArrayList(record));

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -529,22 +529,22 @@ public class LibraryAdderTest {
         // Change the library path to lib1 - build should succeed and cache the global library at the lib1 level
         ((SCMBasedRetriever) globalLib.getRetriever()).setLibraryPath("libs/lib1");
         b = r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
-        r.assertLogContains("Library global@master from libraryPath: libs/lib1/ successfully cached.", b);
+        r.assertLogContains("Library global@master:libs/lib1/ successfully cached.", b);
         r.assertLogContains("global library 1", b);
         // Change the library path to lib2 - build should succeed and cache the global library at the lib2 level
         ((SCMBasedRetriever) globalLib.getRetriever()).setLibraryPath("libs/lib2");
         b = r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0));
-        r.assertLogContains("Library global@master from libraryPath: libs/lib2/ successfully cached.", b);
+        r.assertLogContains("Library global@master:libs/lib2/ successfully cached.", b);
         r.assertLogContains("global library 2", b);
         // Change the library path to lib3 - build fails with an empty library
         ((SCMBasedRetriever) globalLib.getRetriever()).setLibraryPath("libs/lib3");
         b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        r.assertLogContains("Caching library global@master from libraryPath: libs/lib3/", b);
-        r.assertLogContains("Library global@master from libraryPath: libs/lib3/ is empty after retrieval in job p. Cleaning up cache directory.", b);
+        r.assertLogContains("Caching library global@master:libs/lib3/", b);
+        r.assertLogContains("Library global@master:libs/lib3/ is empty after retrieval in job p. Cleaning up cache directory.", b);
         // Subsequent builds should fail as well
         b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
-        r.assertLogContains("Caching library global@master from libraryPath: libs/lib3/", b);
-        r.assertLogContains("Library global@master from libraryPath: libs/lib3/ is empty after retrieval in job p. Cleaning up cache directory.", b);
+        r.assertLogContains("Caching library global@master:libs/lib3/", b);
+        r.assertLogContains("Library global@master:libs/lib3/ is empty after retrieval in job p. Cleaning up cache directory.", b);
     }
 }
 


### PR DESCRIPTION
This pull request:

- adds a new `EMPTY` status to the CacheStatus
- adds an additional empty check to the caching process of the `LibraryAdder`
- adds the notion of the `libraryPath` to the caching directory name
  - up until now, the same cache was return even if the `libraryPath` on the shared library configuration had changed 
- adds tests

### Steps to reproduce

####  libraryPath not considered

Consider a repo with multiple libraries

```sh
├── another-lib
│   └── vars
│       └── echoMe.groovy # echos "from another"
└── vars
    └── echoMe.groovy # echos "from root"
```

- add a library pointing to a the repo
- add a caching config of 5 mins
- try to use the library
  - pipeline echo's "from root"
  - subsequent builds with also echo "from root"
- change the "Library Path" field to another-lib
  - the wrong (old) pipeline is still checked and seen as cached
  - pipeline still echo's "from root" until the cache expires

#### Empty library on checkout

- add a library pointing to a the repo
- add a caching config of 5 mins
- ensure the library is pointing to a location without `vars` or `src` directories
  - for the sake of testing, add "vars" in the "Library Path" field (pretend it was a mistake)
- try to use the library
  - pipeline fails with "No vars or src directory"
  - subsequent builds with also fail until the cache expires
  - any other pipelines using that library will also fail

#### Empty library do to something unexpected

- add a library pointing to a the repo
- add a caching config of 5 mins
- try to use the library
  - pipeline echo's "from root"
  - subsequent builds with also echo "from root"
- manually delete the src and vars libraries cache directory (this is unexpected and just meant to represent something going wrong during retrieval)
  - pipeline fails with "No vars or src directory"
  - subsequent builds with also fail until the cache expires
  - any other pipelines using that library will also fail
- once the cache expires and the library is retrieved again, the builds will continue


### Context

Although using [the version which should have fixed the issue](https://issues.jenkins.io/browse/JENKINS-69573?focusedId=447294&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-447294), some jobs have shown the following:

```mono
Loading library <library>
Library <library> is cached. Copying from home.
ERROR: Library <library> expected to contain at least one of src or vars directories
[Bitbucket] Notifying commit build result
[Bitbucket] Build result notified
Finished: FAILURE
```

- To be sure something has actually been retrieved, a check has been added post-retrieval.
- This way, if the retrieval somehow fails silently, the problem is still caught and thrown.
- In addition, a system log WARNING was added to allow easy discovery in this edge case. 

### Testing done

Tests added to PR.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
