### PR TITLE
Use NIO Ivy file lock strategy

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GrapeHack.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GrapeHack.java
@@ -35,10 +35,19 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.ivy.core.cache.DefaultRepositoryCacheManager;
+import org.apache.ivy.core.cache.RepositoryCacheManager;
+import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.plugins.lock.LockStrategy;
+import org.apache.ivy.plugins.lock.NoLockStrategy;
 
 public class GrapeHack {
 
     private static final Logger LOGGER = Logger.getLogger(GrapeHack.class.getName());
+
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static boolean DISABLE_NIO_FILE_LOCK =
+            Boolean.getBoolean(GrapeHack.class.getName() + ".DISABLE_NIO_FILE_LOCK");
 
     @SuppressFBWarnings(value="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification="the least of our concerns")
     @Initializer(after=InitMilestone.PLUGINS_PREPARED, fatal=false)
@@ -63,6 +72,32 @@ public class GrapeHack {
         l = engine.getClass().getClassLoader();
         LOGGER.log(Level.FINE, "was also able to load {0}", l.loadClass(ivyGrabRecordName));
         LOGGER.log(Level.FINE, "linked to {0}", l.loadClass("org.apache.ivy.core.module.id.ModuleRevisionId").getProtectionDomain().getCodeSource().getLocation());
+        if (!DISABLE_NIO_FILE_LOCK) {
+            try {
+                /*
+                 * We must use reflection instead of simply casting to GrapeIvy and invoking directly due to the use of
+                 * MaskingClassLoader a few lines above.
+                 */
+                IvySettings settings = (IvySettings) c.getMethod("getSettings").invoke(instance.get(null));
+                RepositoryCacheManager repositoryCacheManager = settings.getDefaultRepositoryCacheManager();
+                if (repositoryCacheManager instanceof DefaultRepositoryCacheManager) {
+                    DefaultRepositoryCacheManager defaultRepositoryCacheManager =
+                            (DefaultRepositoryCacheManager) repositoryCacheManager;
+                    LockStrategy lockStrategy = defaultRepositoryCacheManager.getLockStrategy();
+                    LOGGER.log(Level.FINE, "default lock strategy {0}", lockStrategy);
+                    if (lockStrategy == null || lockStrategy instanceof NoLockStrategy) {
+                        lockStrategy = settings.getLockStrategy("artifact-lock-nio");
+                        if (lockStrategy != null) {
+                            defaultRepositoryCacheManager.setLockStrategy(lockStrategy.getName());
+                            defaultRepositoryCacheManager.setLockStrategy(lockStrategy);
+                        }
+                    }
+                    LOGGER.log(Level.FINE, "using lock strategy {0}", defaultRepositoryCacheManager.getLockStrategy());
+                }
+            } catch (RuntimeException | LinkageError x) {
+                LOGGER.log(Level.FINE, "failed to enable NIO file lock", x);
+            }
+        }
     }
 
     private GrapeHack() {}


### PR DESCRIPTION
### Background

See [JENKINS-72050](https://issues.jenkins.io/browse/JENKINS-72050). Ivy 2.5.2 (a security release) introduced flakiness in `@Grab` relating to XML parsing. After upgrading to 2.5.3, this regression was apparently resolved, but a user has still noticed that `@Grab` is still flaky.

### Problem

See [JENKINS-72050 (comment)](https://issues.jenkins.io/browse/JENKINS-72050?focusedId=451809&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-451809). Building 14 Pipeline jobs in parallel, each of which uses `@Grab`, results in failures. These failures are not present when running the jobs sequentially.

### Evaluation

See [IVY-654 (comment)](https://issues.apache.org/jira/browse/IVY-654?focusedCommentId=15860959&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15860959). As described by [@danielcwc](https://issues.jenkins.io/secure/ViewProfile.jspa?name=danielcwc), the default Ivy cache has no lock protection. From https://ant.apache.org/ivy/history/2.5.3/concept.html#cache:

> This part of the cache can be shared if you use a well suited [lock strategy](https://ant.apache.org/ivy/history/2.5.3/settings/lock-strategies.html).

From https://ant.apache.org/ivy/history/2.5.3/settings/caches.html:

> `lockStrategy` […] defaults to `no-lock `

From https://ant.apache.org/ivy/history/2.5.3/settings/lock-strategies.html:

> `no-lock` This lock strategy actually performs no locking at all, and thus should not be used in an environment where the cache is shared by multiple processes. 

From this we can see that the bug is a classic race condition.

### Solution

Use a file locking strategy, such as

> `artifact-lock` This strategy acquires a lock whenever a module descriptor or an artifact is downloaded to the cache, which makes a good solution when you want to share your repository cache. Note that this strategy is based on file locking, performed by default using the `java.io.File.createNewFile()` atomicity (which is documented as atomic in the javadoc, but not recommended to perform locks).

or

> `artifact-lock-nio` (since 2.4) Like the `artifact-lock` strategy, this one also acquires a lock whenever a module descriptor or artifact is downloaded to the cache. But here the implementation is done with a `java.nio.FileLock`.

### Implementation

A proper implementation would be to add `<caches lockStrategy="artifact-lock-nio" />` below https://github.com/apache/groovy/blob/de5ff81e020b25289c2eba8f245d46118e3c799f/src/resources/groovy/grape/defaultGrapeConfig.xml#L22 in Groovy's `defaultGrapeConfig.xml`. However, this would involve making a change to Groovy upstream, waiting for that to be released, and then upgrading to that release, a nontrivial endeavor.

Instead, we change the lock strategy in `GrapeHack` (introduced in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/9) from its default of `no-lock` to `artifact-lock-nio`, offering an escape hatch in case the user has any problems. This works around the upstream Groovy issue without requiring us to patch and release a new version of Groovy.

### Testing done

Ran the test described in the linked issue comment. Reproduced the failure when running 14 parallel jobs before this PR. Could no longer reproduce the failure after this PR.

Verified in the debugger and by viewing `FINE`-level logs that the workaround was executing as expected, that the lock strategy was `no-lock` before `GrapeHack` executed, and that the lock strategy was `artifact-lock-nio` after `GrapeHack` executed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
