### PR TITLE
Fix PCT failure in `FolderLibrariesTest#configRoundtrip`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3875.v1df09947cde6</version>
+                <version>3893.v213a_42768d35</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Amends #149 to fix this PCT failure in `FolderLibrariesTest#configRoundtrip`:

```
h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID 1c7ae3ff-e8da-4d58-a7df-8fd0e0f0796d
java.lang.StackOverflowError
        at com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor.newInstance(AbstractFolderPropertyDescriptor.java:43)
        at org.jenkinsci.plugins.workflow.libs.FolderLibraries$DescriptorImpl.newInstance(FolderLibraries.java:61)
        at com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor.newInstance(AbstractFolderPropertyDescriptor.java:43)
        at org.jenkinsci.plugins.workflow.libs.FolderLibraries$DescriptorImpl.newInstance(FolderLibraries.java:61)
        at com.cloudbees.hudson.plugins.folder.AbstractFolderPropertyDescriptor.newInstance(AbstractFolderPropertyDescriptor.java:43)
        at org.jenkinsci.plugins.workflow.libs.FolderLibraries$DescriptorImpl.newInstance(FolderLibraries.java:61)
```

### Testing done

`mvn -Dtest=FolderLibrariesTest#configRoundtrip -DoverrideWar=megawar-weekly.war -Djenkins.version=2.496 -DuseUpperBounds=true clean verify`