### PR TITLE
Remove `useBeta` property from `pom.xml`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,8 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <!--jenkins.version>${jenkins.baseline}.1</jenkins.version-->
-        <!-- REMOVE -->
-        <jenkins.version>2.495</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
@@ -75,7 +73,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3893.v213a_42768d35</version>
+                <version>4948.vcf1d17350668</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,10 @@
         <changelist>999999-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <!--jenkins.version>${jenkins.baseline}.1</jenkins.version-->
+        <!-- REMOVE -->
+        <jenkins.version>2.495</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <useBeta>true</useBeta>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Now that the permission `Jenkins.MANAGE` is out of beta (https://github.com/jenkinsci/jenkins/pull/10183) the `useBeta` property is no longer required.

This is still a draft, since it will take some time until that change is shipped in an LTS and this plugin updates to it.
I would like to use this PR as a reminder and update / merge it once the requirements are met.

### Testing done

Validated with `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
