### PR TITLE
Add test for grabbed class cleanup after Pipeline completion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,15 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>4948.vcf1d17350668</version>
+                <version>5043.v855ff4819a_0f</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/1086 -->
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-cps</artifactId>
+                <version>4194.v54b_8471101e3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
@@ -26,11 +26,14 @@ package org.jenkinsci.plugins.workflow.libs;
 
 import groovy.lang.MetaClass;
 import hudson.PluginManager;
+import java.io.ObjectStreamClass;
+import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
@@ -38,6 +41,8 @@ import org.codehaus.groovy.reflection.ClassInfo;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.support.storage.BulkFlowNodeStorage;
+import org.junit.Before;
 import static org.junit.Assert.assertFalse;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -55,6 +60,7 @@ public class LibraryMemoryTest {
     @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
     @Rule public LoggerRule logging = new LoggerRule().record(CpsFlowExecution.class, Level.FINER);
 
+    // Using a set to avoid duplicate elements, which just makes `assertGC` slower.
     private static final List<WeakReference<ClassLoader>> LOADERS = new ArrayList<>();
     public static void register(Object o) {
         System.err.println("registering " + o);
@@ -63,6 +69,12 @@ public class LibraryMemoryTest {
             LOADERS.add(new WeakReference<>(loader));
         }
     }
+
+    @Before
+    public void cleanUp() {
+        LOADERS.clear();
+    }
+
     @Issue("JENKINS-50223")
     @Test public void loaderReleased() throws Exception {
         sampleRepo.init();
@@ -75,14 +87,82 @@ public class LibraryMemoryTest {
         p.setDefinition(new CpsFlowDefinition("@Library('leak@master') _; " + LibraryMemoryTest.class.getName() + ".register(this); leak(); new p.C()", false));
         r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertFalse(LOADERS.isEmpty());
-        { // cf. CpsFlowExecutionMemoryTest
+        {
+            // cf. CpsFlowExecutionMemoryTest
             MetaClass metaClass = ClassInfo.getClassInfo(LibraryMemoryTest.class).getMetaClass();
             Method clearInvocationCaches = metaClass.getClass().getDeclaredMethod("clearInvocationCaches");
             clearInvocationCaches.setAccessible(true);
             clearInvocationCaches.invoke(metaClass);
+
+            // Force ObjectStreamClass$Caches.localDesc -> ClassCache.processQueue, otherwise ClassCache.type sometimes references the script.
+            // TODO: Does this need to go into CpsFlowExecution.cleanUpHeap?
+            // Also, this is inconsistent (or maybe useless), sometimes it still shows up in "Apparent soft references..."
+            ObjectStreamClass.lookup(String.class);
         }
         for (WeakReference<ClassLoader> loaderRef : LOADERS) {
-            MemoryAssert.assertGC(loaderRef);
+            MemoryAssert.assertGC(loaderRef, false);
+        }
+    }
+
+    @Test public void loaderReleasedWithGrab() throws Exception {
+        {
+            // http-builder loads xerces stuff that XStream has special handling for, and apparently if BulkFlowNodeStorage
+            // is first loaded by a Pipeline that uses @Grab, the grabbed stuff will be available when BulkFlowNodeStorage.XSTREAM2
+            // is instantiated and then strongly retained, so we need to avoid that.
+            // Specifically com.thoughtworks.xstream.converters.extended.DurationConverter and org.apache.xerces.jaxp.datatype.DatatypeFactoryImpl
+            // TODO: Do we need an @Initializer for BulkFlowNodeStorage.XSTREAM to avoid this?
+            BulkFlowNodeStorage.XSTREAM.getClass();
+        }
+        sampleRepo.init();
+        sampleRepo.write("vars/util.groovy",
+                "@Grab(group='org.codehaus.groovy.modules.http-builder', module='http-builder', version='0.7.1')\n" +
+                "import groovyx.net.http.RESTClient\n" +
+                "def call(body) {\n" +
+                "  return\n" +
+                "}\n" +
+                "");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(new LibraryConfiguration("leak3", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('leak3@master') _; " + LibraryMemoryTest.class.getName() + ".register(this); util()", false));
+        r.buildAndAssertSuccess(p);
+        assertFalse(LOADERS.isEmpty());
+        {
+            // cf. CpsFlowExecutionMemoryTest
+            MetaClass metaClass = ClassInfo.getClassInfo(LibraryMemoryTest.class).getMetaClass();
+            Method clearInvocationCaches = metaClass.getClass().getDeclaredMethod("clearInvocationCaches");
+            clearInvocationCaches.setAccessible(true);
+            clearInvocationCaches.invoke(metaClass);
+
+            // Force ObjectStreamClass$Caches.localDesc -> ClassCache.processQueue, otherwise ClassCache.type references util.
+            // TODO: Does this need to go into CpsFlowExecution.cleanUpHeap?
+            // Also, this is inconsistent (or maybe useless), sometimes it still shows up in "Apparent soft references..."
+            ObjectStreamClass.lookup(String.class);
+
+            // TODO: GrapeIvy's $callSiteArray softly references `util`, why?
+            // It also makes assertGC slow, but it often still passes, even with `allowSoft`, why?
+            /*
+            Apparent soft references to org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$CleanGroovyClassLoader@1ed31c97: {org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$CleanGroovyClassLoader@1ed31c97=private static java.lang.ref.SoftReference groovy.grape.GrapeIvy.$callSiteArray->
+            java.lang.ref.SoftReference@707812c-referent->
+            org.codehaus.groovy.runtime.callsite.CallSiteArray@4c0bfefb-array->
+            [Lorg.codehaus.groovy.runtime.callsite.CallSite;@251238-[44]->
+            org.codehaus.groovy.runtime.callsite.ClassMetaClassGetPropertySite@19a8bc43-aClass->
+            class util@33186969-<changed>->
+            org.jenkinsci.plugins.workflow.cps.CpsGroovyShell$CleanGroovyClassLoader@1ed31c97};
+            */
+            // Also, the following makes no difference:
+            var grapeIvyC = Class.forName("groovy.grape.GrapeIvy");
+            var callSiteArrayF = grapeIvyC.getDeclaredField("$callSiteArray");
+            callSiteArrayF.setAccessible(true);
+            var softRef = ((SoftReference<?>) callSiteArrayF.get(null));
+            softRef.clear();
+        }
+        // TODO: Trying to debug why assertGC(_, false) is slow but still passes
+        var pid = ProcessHandle.current().pid();
+        new ProcessBuilder().command("jmap", "-dump:format=b,file=heap-" + pid + ".bin", String.valueOf(pid)).start().waitFor(10, TimeUnit.SECONDS);
+        for (var loaderRef : LOADERS) {
+            MemoryAssert.assertGC(loaderRef, false);
         }
     }
 


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-cps-plugin/pull/1086.

I am trying to test the fix, but `MemoryAssert.assertGc` is giving inconsistent results.

### Testing done

See new automated tests.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
