### PR TITLE
Add regression test for SECURITY-3727 symlinked resources/ root

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -207,6 +207,31 @@ public class ResourceStepTest {
         r.assertLogContains("Rejecting library: symlink found", r.buildAndAssertStatus(Result.FAILURE, p));
     }
 
+    @Issue("SECURITY-3727")
+    @Test public void symlinkedLibraryResourcesDirectoryIsNotAllowedToEscapeWorkspaceContext() throws Exception {
+        assumeFalse("Git symlink behavior is platform dependent on Windows", Functions.isWindows());
+        Path secretsDir = r.jenkins.getRootDir().toPath().resolve("secrets");
+        Files.createDirectories(secretsDir);
+        Files.write(secretsDir.resolve("poc.txt"), Arrays.asList("controller-secret-from-jenkins-home"), StandardCharsets.UTF_8);
+
+        sampleRepo.init();
+        sampleRepo.write("src/Stuff.groovy", "class Stuff {static def contents(script) {script.libraryResource 'poc.txt'}}");
+        Files.createSymbolicLink(Paths.get(sampleRepo.getRoot().getPath(), "resources"), secretsDir);
+
+        sampleRepo.git("add", "src", "resources");
+        sampleRepo.git("commit", "--message=init");
+        for (boolean clone : new boolean[] {false, true}) {
+            SCMSourceRetriever scm = new SCMSourceRetriever(new GitSCMSource(sampleRepo.toString()));
+            scm.setClone(clone);
+            GlobalLibraries.get().setLibraries(Collections.singletonList(
+                new LibraryConfiguration("symlink-root-stuff", scm)));
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p" + clone);
+            p.setDefinition(new CpsFlowDefinition("@Library('symlink-root-stuff@master') import Stuff; echo(Stuff.contents(this))", true));
+            WorkflowRun b = r.buildAndAssertStatus(Result.FAILURE, p);
+            r.assertLogContains("Rejecting library: symlink found", b);
+        }
+    }
+
     @Issue("SECURITY-2476")
     @Test public void libraryResourceNotAllowedToEscapeWorkspaceContext() throws Exception {
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -216,7 +216,7 @@ public class ResourceStepTest {
 
         sampleRepo.init();
         sampleRepo.write("src/Stuff.groovy", "class Stuff {static def contents(script) {script.libraryResource 'poc.txt'}}");
-        Files.createSymbolicLink(Paths.get(sampleRepo.getRoot().getPath(), "resources"), secretsDir);
+        Files.createSymbolicLink(Paths.get(sampleRepo.getRoot().getPath(), "resources"), Paths.get("../../../../../../../secrets"));
 
         sampleRepo.git("add", "src", "resources");
         sampleRepo.git("commit", "--message=init");

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -210,12 +211,8 @@ public class ResourceStepTest {
     @Issue("SECURITY-3727")
     @Test public void symlinkedLibraryResourcesDirectoryIsNotAllowedToEscapeWorkspaceContext() throws Exception {
         assumeFalse("Git symlink behavior is platform dependent on Windows", Functions.isWindows());
-        Path secretsDir = r.jenkins.getRootDir().toPath().resolve("secrets");
-        Files.createDirectories(secretsDir);
-        Files.write(secretsDir.resolve("poc.txt"), Arrays.asList("controller-secret-from-jenkins-home"), StandardCharsets.UTF_8);
-
         sampleRepo.init();
-        sampleRepo.write("src/Stuff.groovy", "class Stuff {static def contents(script) {script.libraryResource 'poc.txt'}}");
+        sampleRepo.write("src/Stuff.groovy", "class Stuff {static def contents(script) {script.libraryResource 'master.key'}}");
         Files.createSymbolicLink(Paths.get(sampleRepo.getRoot().getPath(), "resources"), Paths.get("../../../../../../../secrets"));
 
         sampleRepo.git("add", "src", "resources");
@@ -223,7 +220,7 @@ public class ResourceStepTest {
         for (boolean clone : new boolean[] {false, true}) {
             SCMSourceRetriever scm = new SCMSourceRetriever(new GitSCMSource(sampleRepo.toString()));
             scm.setClone(clone);
-            GlobalLibraries.get().setLibraries(Collections.singletonList(
+            GlobalLibraries.get().setLibraries(List.of(
                 new LibraryConfiguration("symlink-root-stuff", scm)));
             WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p" + clone);
             p.setDefinition(new CpsFlowDefinition("@Library('symlink-root-stuff@master') import Stuff; echo(Stuff.contents(this))", true));


### PR DESCRIPTION
## Summary

Adds a regression test in `ResourceStepTest` for the [SECURITY-3727](https://www.jenkins.io/security/advisory/2026-05-27/#SECURITY-3727) bypass shape where a shared library's `resources/` directory is itself a Git symlink to a controller-local path. The existing SECURITY-3727 tests in `SCMSourceRetrieverTest` cover symlinked files inside `vars/` and a symlinked `vars/` directory, but not a symlinked `resources/` root specifically and not the end-to-end path through the `libraryResource` step.

Lives in `ResourceStepTest` rather than alongside the sibling cases because this test asserts the data path through `libraryResource`, not just rejection at retrieval. Exercises both `setClone(false)` and `setClone(true)`.
